### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server that provides access to Swiss legal commentaries from [onlinekommentar.ch](https://onlinekommentar.ch). This server allows you to search and retrieve detailed legal commentaries on Swiss federal law through Claude Desktop or other MCP-compatible clients.
 
+<a href="https://glama.ai/mcp/servers/@self-tech-labs/onlinekommentar-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@self-tech-labs/onlinekommentar-mcp/badge" alt="Online Kommentar Server MCP server" />
+</a>
+
 ## Features
 
 - **Search Commentaries**: Full-text search across legal commentaries with filtering options
@@ -42,7 +46,7 @@ A Model Context Protocol (MCP) server that provides access to Swiss legal commen
 
 Add the following configuration to your Claude Desktop MCP settings file:
 
-**On macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+**On macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`  
 **On Windows**: `%APPDATA%/Claude/claude_desktop_config.json`
 
 ```json


### PR DESCRIPTION
This PR adds a badge for the [Online Kommentar MCP Server](https://glama.ai/mcp/servers/@self-tech-labs/onlinekommentar-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@self-tech-labs/onlinekommentar-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@self-tech-labs/onlinekommentar-mcp/badge" alt="Online Kommentar Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.